### PR TITLE
fix: ignore sbom.json in prettier formatting checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 .agent-os/.obsidian/
 pnpm-lock.yaml
 .github/workflows/ci.yml
+sbom.json


### PR DESCRIPTION
## Summary
- Add sbom.json to .prettierignore to prevent release workflow failures
- Generated SBOM files don't need to conform to prettier formatting standards
- Resolves git push failure in changeset release process due to formatting violations

## Problem
The release workflow was failing because:
1. SBOM generation creates sbom.json with unformatted content
2. Pre-push hooks run prettier format:check which fails on sbom.json
3. Git push gets rejected, breaking the changeset release process

## Solution
- Added `sbom.json` to `.prettierignore` to exclude it from formatting checks
- Generated files like SBOM don't need to follow code formatting standards
- Release workflow can now complete successfully

## Test plan
- [x] All tests pass (750 tests)
- [x] Prettier format:check passes even with unformatted sbom.json
- [x] Release workflow will no longer fail on SBOM formatting

🤖 Generated with [Claude Code](https://claude.ai/code)