### PR TITLE
fix: prevent private packages from being published

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,9 +40,5 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "devDependencies": {},
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
## Summary
Remove conflicting publishConfig from @template/utils package that was causing private packages to be included in changeset releases.

## Problem
The @template/utils package is marked as `"private": true` but also has a `publishConfig` section with `"access": "public"`. This conflicting configuration causes Changesets to treat it as publishable, overriding the private field.

## Solution
Remove the `publishConfig` section from private packages to ensure they are not included in changeset releases.

## Test plan
- [x] Verify @template/utils package.json has `"private": true`
- [x] Verify publishConfig section has been removed
- [ ] Changeset release PR should not include private packages

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package publishing configuration to streamline release settings for utility modules.
  * Removed unused publishing options; build and distribution metadata were cleaned up.
  * No changes to functionality, APIs, scripts, or exports.
  * This is a maintenance update with no impact on end-user experience; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->