### PR TITLE
fix: exclude private packages from changeset releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,5 +5,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@template/utils", "@template/app"]
 }


### PR DESCRIPTION
## Summary
- Added @template/utils and @template/app to the changeset ignore list
- Prevents private packages from appearing in release PRs

## Problem
PR #26 (the automated changeset release PR) was showing @template/utils and @template/app as packages to be published, even though they are marked as private in their package.json files.

## Solution  
Updated .changeset/config.json to explicitly ignore these private packages so they won't appear in future release PRs.

## Test Plan
- [ ] Verify changeset ignores private packages
- [ ] Check that only public packages appear in release notes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release management configuration to exclude certain internal packages from change tracking and publishing, refining versioning and release workflows.
  - No user-facing impact: this adjustment does not alter application features, behavior, or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->