### PR TITLE
fix: add repository field for npm provenance

### DIFF
--- a/packages/quality-check/package.json
+++ b/packages/quality-check/package.json
@@ -65,5 +65,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nathanvale/bun-changesets-template"
   }
 }


### PR DESCRIPTION
Add missing repository field to quality-check package.json to fix npm provenance verification error during publishing.

The @claude-hooks/voice-vault package published successfully, but @claude-hooks/quality-check failed with:
```
Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "", expected to match "https://github.com/nathanvale/bun-changesets-template"
```

This PR adds the required repository field to enable successful package publishing with npm provenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for the quality-check package to include repository information (Git URL). This improves transparency and links from package managers to the project’s source and issue tracker. No changes to functionality, performance, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->