### PR TITLE
fix: correct changeset package name to unblock releases

### DIFF
--- a/.changeset/ci-workflow-optimizations.md
+++ b/.changeset/ci-workflow-optimizations.md
@@ -1,5 +1,5 @@
 ---
-"@template/quality-check": patch
+"@claude-hooks/quality-check": patch
 ---
 
 feat: comprehensive CI/CD workflow optimizations with Turbo cache maximization


### PR DESCRIPTION
## 🚨 Critical Fix for Release Workflow

The release workflow on main is currently broken with this error:
```
Error: Found changeset ci-workflow-optimizations for package @template/quality-check which is not in the workspace
```

## Problem
The changeset file references `@template/quality-check` but the actual package name is `@claude-hooks/quality-check`.

## Solution
This PR corrects the package name in the changeset file so the release workflow can:
- ✅ Read the changeset correctly
- ✅ Identify the quality-check package
- ✅ Create version bump PRs
- ✅ Publish releases

## Impact
**This unblocks all releases on the main branch.**

🤖 Generated with [Claude Code](https://claude.ai/code)