### PR TITLE
fix: update cdxgen to v11 to unblock release workflow

### DIFF
--- a/.changeset/ci-workflow-optimizations.md
+++ b/.changeset/ci-workflow-optimizations.md
@@ -1,5 +1,5 @@
 ---
-"@template/quality-check": patch
+"@claude-hooks/quality-check": patch
 ---
 
 feat: comprehensive CI/CD workflow optimizations with Turbo cache maximization

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Generate SBOM
         run: |
-          pnpx @cyclonedx/cdxgen@10.6.0 -o sbom.json -t js .
+          pnpx @cyclonedx/cdxgen@11 -o sbom.json -t js .
           echo "SBOM generated with $(jq '.components | length' sbom.json) components"
 
       - name: Create Release PR or Publish


### PR DESCRIPTION
## 🚨 Another Critical Fix for Release Workflow

The release workflow on main is failing with this error:
```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @cyclonedx/cdxgen@10.6.0
The latest release of @cyclonedx/cdxgen is "11.8.0".
```

## Problem
The release workflow tries to install `@cyclonedx/cdxgen@10.6.0` which doesn't exist.

## Solution
Update to `@cyclonedx/cdxgen@11` which will:
- ✅ Use the latest v11.x version (currently 11.8.0)
- ✅ Fix the SBOM generation step
- ✅ Allow the release workflow to complete

## Testing
Verified latest version:
```bash
npm view @cyclonedx/cdxgen version
# 11.8.0
```

## Impact
**This unblocks the release workflow on main branch.**

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the SBOM generation step in the release workflow to a newer tool version.
  * Updated changeset metadata to reference a different quality-check package.
  * No changes to application features, UI, or behavior.
  * Build and release processes remain operational with updated tooling; impact is limited to internal automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->