### PR TITLE
fix: make pre-push hook sh-compatible for CI

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 echo "🔍 Running pre-push validation..."
 echo "⏱️ This includes linting, typechecking, testing, and changeset validation"

--- a/scripts/compute-base.sh
+++ b/scripts/compute-base.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Compute the best base reference for change detection
 # Used by pre-push hooks and CI workflows to ensure consistent base detection
@@ -6,7 +6,7 @@
 # Usage: source scripts/compute-base.sh
 # Exports: TURBO_SCM_BASE
 
-set -euo pipefail
+set -eu
 
 # Ensure base refs exist locally for reliable diffing
 git fetch -q origin main 2>/dev/null || true


### PR DESCRIPTION
## 🚨 Third Critical Fix for Release Workflow

The release workflow is failing when trying to push changes:
```
.husky/pre-push: 2: set: Illegal option -o pipefail
husky - pre-push script failed (code 2)
```

## Problem
The pre-push hook uses `bash` with `pipefail` option, but in GitHub Actions CI environment it's executed with `sh` which doesn't support `pipefail`.

## Solution
Make both pre-push hook and compute-base.sh sh-compatible:
- ✅ Changed shebang from `#!/usr/bin/env bash` to `#!/usr/bin/env sh`
- ✅ Removed `pipefail` option (bash-specific)
- ✅ Scripts now work in any POSIX shell environment

## Testing
Validated both scripts are sh-compatible:
```bash
sh -n .husky/pre-push        # No errors
sh -n scripts/compute-base.sh # No errors
```

## Impact
**This allows the release workflow to push changes without hook failures.**

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Migrated development hooks and utility scripts to a POSIX-compliant shell for better cross-platform compatibility.
  - Adjusted shell strictness flags while preserving existing validations and outputs.
  - Minor formatting cleanups for consistency.
  - No user-facing functionality changes; application behavior and public interfaces remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->