### PR TITLE
fix: ensure CI always runs on changeset release PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,88 @@
+# GitHub Workflows Documentation
+
+## Workflows Overview
+
+### CI Workflow (`ci.yml`)
+Main CI pipeline that runs on all PRs and pushes to main/develop branches.
+
+**Triggers:**
+- Pull requests (all branches)
+- Pushes to main, develop, and changeset-release branches
+- Manual workflow dispatch
+
+### Release Workflow (`release.yml`)
+Handles package releases using changesets.
+
+**Triggers:**
+- Pushes to main branch
+- Manual workflow dispatch
+
+### Changeset PR Trigger (`changeset-pr-trigger.yml`)
+Ensures CI runs on changeset release PRs created by bots.
+
+**Why this exists:**
+GitHub Actions bot-created PRs sometimes don't trigger CI workflows automatically. This workflow detects when a changeset release PR is created without CI checks and triggers them by pushing an empty commit.
+
+**How it works:**
+1. Detects PRs created by `github-actions[bot]` from `changeset-release/*` branches
+2. Checks if CI is already running
+3. If not, pushes an empty commit to trigger CI
+4. Comments on the PR to notify about the action
+
+### Weekly Paranoid Tests (`weekly-paranoid.yml`)
+Comprehensive weekly testing suite for deep validation.
+
+**Includes:**
+- Full coverage analysis
+- Stress testing
+- Concurrency testing
+- Memory leak detection
+- Turbo cache analysis
+
+### Nightly Performance Benchmarks (`nightly-performance.yml`)
+Currently disabled - runs performance benchmarks and creates issues if regressions detected.
+
+## Common Issues and Solutions
+
+### Issue: Changeset Release PR has no CI checks
+**Solution:** The `changeset-pr-trigger.yml` workflow automatically handles this. If needed manually:
+```bash
+# Push an empty commit to the changeset branch
+git checkout changeset-release/main
+git commit --allow-empty -m "chore: trigger CI"
+git push
+```
+
+### Issue: CI not triggering on PR
+**Solutions:**
+1. Close and reopen the PR
+2. Push an empty commit
+3. Check if branch protection rules are blocking
+
+## Workflow Dependencies
+
+```mermaid
+graph TD
+    A[PR Created] --> B[CI Workflow]
+    A --> C[Changeset PR Trigger]
+    C --> B
+    B --> D[Tests Pass]
+    D --> E[Merge PR]
+    E --> F[Release Workflow]
+    F --> G[Publish to NPM]
+```
+
+## Environment Variables
+
+### Required Secrets
+- `NPM_TOKEN` - For publishing packages
+- `TURBO_TOKEN` - For Turbo remote cache
+- `TURBO_TEAM` - Turbo team identifier
+- `TURBO_REMOTE_CACHE_SIGNATURE_KEY` - For cache signing
+
+### Workflow Permissions
+Most workflows require:
+- `contents: read`
+- `pull-requests: write` (for commenting)
+- `checks: write` (for test reports)
+- `id-token: write` (for NPM provenance)

--- a/.github/workflows/changeset-pr-trigger.yml
+++ b/.github/workflows/changeset-pr-trigger.yml
@@ -1,0 +1,77 @@
+name: Changeset PR CI Trigger
+
+# This workflow ensures CI runs on changeset release PRs
+# Even if created by bots (which sometimes don't trigger CI automatically)
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write
+
+jobs:
+  trigger-ci:
+    name: Ensure CI Runs on Changeset PRs
+    runs-on: ubuntu-latest
+    # Only run for changeset release PRs created by the GitHub bot
+    if: |
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if CI is running
+        id: check-ci
+        run: |
+          # Wait a moment for CI to potentially start
+          sleep 10
+
+          # Check if there are any check runs for this SHA
+          CHECK_COUNT=$(gh api \
+            repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs \
+            --jq '.total_count')
+
+          echo "check_count=$CHECK_COUNT" >> $GITHUB_OUTPUT
+
+          if [ "$CHECK_COUNT" -eq "0" ]; then
+            echo "❌ No CI checks found, will trigger CI"
+            echo "needs_trigger=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ CI is already running ($CHECK_COUNT checks found)"
+            echo "needs_trigger=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger CI with empty commit
+        if: steps.check-ci.outputs.needs_trigger == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create an empty commit to trigger CI
+          git commit --allow-empty -m "chore: trigger CI for changeset release PR [skip ci]"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR
+        if: steps.check-ci.outputs.needs_trigger == 'true'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "🤖 **CI Trigger Bot**
+
+          I've detected this is a changeset release PR without CI checks running.
+          An empty commit has been pushed to trigger the CI workflow.
+
+          This is an automated action to ensure all release PRs pass CI before merging."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,10 @@ name: ADHD CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches:
+      - '**'  # Run on all PRs including changeset-release/*
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'changeset-release/**']  # Also trigger on changeset branches
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem
Changeset release PRs created by the GitHub Actions bot don't always trigger CI workflows automatically. This causes the PRs to appear as 'blocked' even when there are no branch protection rules, making them unmergeable.

## Solution
This PR implements a two-pronged approach to ensure CI always runs on changeset release PRs:

### 1. Updated CI Workflow Triggers
- CI now triggers on **all** PR branches (not just specific ones)
- Added `changeset-release/**` to push triggers
- This ensures CI runs when the changeset bot creates or updates PRs

### 2. New Changeset PR Trigger Workflow
- Detects when a changeset release PR is created by `github-actions[bot]`
- Checks if CI is already running
- If not, automatically pushes an empty commit to trigger CI
- Comments on the PR to notify about the action

### 3. Documentation
- Added comprehensive workflow documentation in `.github/workflows/README.md`
- Includes troubleshooting guide and workflow dependency diagram

## Impact
✅ Changeset release PRs will always have CI checks
✅ No more manual intervention needed to trigger CI
✅ Release process becomes fully automated again
✅ Clear documentation for future maintainers

## Testing
The solution will be validated when the next changeset release PR is created. The new workflow will:
1. Detect the bot-created PR
2. Check for CI status
3. Trigger CI if needed
4. Report its action in the PR comments

Fixes #96 (the issue with unmergeable release PRs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide to our GitHub workflows, covering CI, Release, weekly tests, and nightly benchmarks (currently disabled), with triggers, interactions, troubleshooting steps, required environment variables, permissions, and a dependency diagram.
* **Chores**
  * Introduced automation to ensure CI runs on changeset release PRs created by the bot, triggering CI and commenting when needed.
  * Broadened CI triggers to run on all PR branches and pushes to changeset-release branches for improved coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->