### PR TITLE
fix: update changeset to use @orchestr8 scope

### DIFF
--- a/.changeset/fix-coverage-threshold.md
+++ b/.changeset/fix-coverage-threshold.md
@@ -1,5 +1,5 @@
 ---
-"@template/testkit": patch
+"@orchestr8/testkit": patch
 ---
 
 fix: lower coverage threshold to 68% to match actual coverage


### PR DESCRIPTION
## Summary
- Fixed changeset file that still referenced `@template/testkit` instead of `@orchestr8/testkit`
- This was causing the release workflow to fail after PR #103 merged

## Context
The release workflow was failing with:
```
Error: Found changeset fix-coverage-threshold for package @template/testkit which is not in the workspace
```

This was a leftover from before the scope migration to @orchestr8.

## Changes
- Updated `.changeset/fix-coverage-threshold.md` to use `@orchestr8/testkit`

## Test Plan
- [x] Verified `pnpm changeset status` works correctly locally
- [ ] Release workflow should succeed once this is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted test coverage threshold to stabilize CI and release workflows. No impact on app behavior or user experience.
  * Updated internal release configuration, resulting in a patch-level version bump.

* **Documentation**
  * Added a changelog note explaining the coverage threshold adjustment and its rationale.
  * Clarified that this release contains no functional changes for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->