### PR TITLE
fix: improve changeset PR CI triggering mechanism

### DIFF
--- a/.github/workflows/changeset-pr-trigger.yml
+++ b/.github/workflows/changeset-pr-trigger.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
       - develop
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to trigger CI for'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -18,26 +24,41 @@ jobs:
   trigger-ci:
     name: Ensure CI Runs on Changeset PRs
     runs-on: ubuntu-latest
-    # Only run for changeset release PRs created by GitHub bot/app
-    # Handle both 'github-actions[bot]' and 'app/github-actions' formats
+    # Only run for changeset release PRs (automatic trigger)
+    # OR when manually triggered via workflow_dispatch
     if: |
-      (github.event.pull_request.user.login == 'github-actions[bot]' ||
-       github.event.pull_request.user.login == 'app/github-actions' ||
-       github.event.pull_request.user.type == 'Bot') &&
-      startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+      github.event_name == 'workflow_dispatch' ||
+      (startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
+       (github.event.pull_request.user.type == 'Bot' ||
+        endsWith(github.event.pull_request.user.login, '[bot]')))
     steps:
-      - name: Debug PR Info
+      - name: Get PR Info
+        id: pr-info
         run: |
-          echo "PR Author: ${{ github.event.pull_request.user.login }}"
-          echo "PR Author Type: ${{ github.event.pull_request.user.type }}"
-          echo "PR Branch: ${{ github.event.pull_request.head.ref }}"
-          echo "Is Bot: ${{ github.event.pull_request.user.type == 'Bot' }}"
-          echo "Is Changeset Branch: ${{ startsWith(github.event.pull_request.head.ref, 'changeset-release/') }}"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            PR_NUM="${{ github.event.inputs.pr_number }}"
+            echo "Manual trigger for PR #$PR_NUM"
+            PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM)
+            PR_HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+            PR_HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+          else
+            PR_NUM="${{ github.event.pull_request.number }}"
+            PR_HEAD_REF="${{ github.event.pull_request.head.ref }}"
+            PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            echo "PR Author: ${{ github.event.pull_request.user.login }}"
+            echo "PR Author Type: ${{ github.event.pull_request.user.type }}"
+          fi
+          echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
+          echo "pr_head_ref=$PR_HEAD_REF" >> $GITHUB_OUTPUT
+          echo "pr_head_sha=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "PR Branch: $PR_HEAD_REF"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ steps.pr-info.outputs.pr_head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if CI is running
@@ -48,7 +69,7 @@ jobs:
 
           # Check if there are any check runs for this SHA
           CHECK_COUNT=$(gh api \
-            repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs \
+            repos/${{ github.repository }}/commits/${{ steps.pr-info.outputs.pr_head_sha }}/check-runs \
             --jq '.total_count')
 
           echo "check_count=$CHECK_COUNT" >> $GITHUB_OUTPUT
@@ -71,14 +92,14 @@ jobs:
 
           # Create an empty commit to trigger CI
           git commit --allow-empty -m "chore: trigger CI for changeset release PR [skip ci]"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin HEAD:${{ steps.pr-info.outputs.pr_head_ref }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on PR
         if: steps.check-ci.outputs.needs_trigger == 'true'
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body "🤖 **CI Trigger Bot**
+          gh pr comment ${{ steps.pr-info.outputs.pr_number }} --body "🤖 **CI Trigger Bot**
 
           I've detected this is a changeset release PR without CI checks running.
           An empty commit has been pushed to trigger the CI workflow.
@@ -87,7 +108,7 @@ jobs:
 
           **Note:** If CI still doesn't run, you may need to manually push an empty commit:
           \`\`\`bash
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git checkout ${{ steps.pr-info.outputs.pr_head_ref }}
           git commit --allow-empty -m \"chore: trigger CI [skip changelog]\"
           git push
           \`\`\`"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   push:
     branches: [main, develop, 'changeset-release/**']  # Also trigger on changeset branches
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Enable debug logging'
+        required: false
+        default: false
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Fixed the issue where CI wasn't automatically triggered on changeset release PRs
- PR #105 was stuck without CI checks running

## Root Cause
The changeset bot creates PRs with `github-actions[bot]` as the author, but the `pull_request` event doesn't always fire properly for bot-created PRs. Our trigger workflow had conditions that were too specific.

## Changes
1. **Simplified bot detection**: Now checks for any bot type or login ending with `[bot]`
2. **Added manual trigger**: Added `workflow_dispatch` to manually trigger CI for stuck PRs
3. **Improved PR info handling**: Workflow now handles both automatic and manual triggers
4. **Added CI debug option**: Can enable debug logging when manually triggering CI

## Test Plan
- [x] Verified the workflow changes are valid YAML
- [x] Tested that CI runs on this PR
- [ ] Will monitor next changeset release PR to ensure CI triggers automatically
- [ ] Manual trigger can be tested via Actions tab if needed

## Prevention
This should prevent future changeset release PRs from getting stuck without CI checks. If it happens again, we can:
1. Manually trigger the workflow from Actions tab
2. Push an empty commit to the PR branch (as we did for PR #105)

Fixes the issue seen in PR #105 where status checks were hanging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Manually trigger CI for any pull request by providing its number.
  - Optional debug logging toggle when manually running CI.

- Refactor
  - Unified PR detection to support both manual triggers and automated release PRs.
  - Consistent use of PR metadata across checkout, status checks, pushes, and comments.
  - Clearer PR information step and updated CI trigger comment for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->