### PR TITLE
chore: add changeset for testkit module resolution fixes

### DIFF
--- a/.changeset/fix-testkit-module-resolution-critical.md
+++ b/.changeset/fix-testkit-module-resolution-critical.md
@@ -1,0 +1,11 @@
+---
+"@orchestr8/testkit": patch
+---
+
+Fix critical module resolution issues for vitest/vite environments
+
+- Fixed conditional exports: All `vitest` and `development` conditions now correctly point to built files in `dist/` instead of source files in `src/`
+- Added missing optional peer dependencies: `better-sqlite3`, `convex-test`, `testcontainers`, `mysql2`, and `pg` are now properly declared as optional peer dependencies
+- Resolves "Cannot find package" errors when importing sub-exports like `@orchestr8/testkit/utils`, `@orchestr8/testkit/msw`, etc.
+
+This fix enables proper consumption of @orchestr8/testkit in modern JavaScript toolchains (Vite, Vitest, pnpm workspaces).


### PR DESCRIPTION
The previous changeset was not included in the squash merge of PR #107. This changeset triggers the release of the critical fixes for @orchestr8/testkit module resolution issues.

## What This Does
- Adds a changeset that will trigger a patch release for @orchestr8/testkit
- Fixes will be automatically published to npm once merged

## Context
PR #107 fixed critical module resolution issues but the changeset wasn't included in the merge, so no release was triggered.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved module resolution issues causing “Cannot find package” errors for sub-exports (e.g., utils, msw) in modern toolchains (Vite, Vitest, pnpm).
  * Ensures packages resolve to built distributions for reliable consumption across environments.

* **Chores**
  * Added missing optional peer dependencies to improve install and compatibility: better-sqlite3, convex-test, testcontainers, mysql2, pg.
  * Improved overall compatibility of the testkit in contemporary build/test setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->