### PR TITLE
fix(ci): remove bot-only condition from changeset PR trigger

### DIFF
--- a/.github/workflows/changeset-pr-trigger.yml
+++ b/.github/workflows/changeset-pr-trigger.yml
@@ -1,14 +1,11 @@
 name: Changeset PR CI Trigger
 
-# ⚠️ TEMPORARY WORKAROUND - Can be deleted after setting up CHANGESET_GITHUB_TOKEN
-# This workflow ensures CI runs on changeset release PRs
-# Even if created by bots (which sometimes don't trigger CI automatically)
+# This workflow ensures CI runs on changeset release PRs created by the release workflow.
+# GitHub blocks workflow triggers when PRs are created with a PAT from the repo owner,
+# so this workflow manually triggers CI by pushing an empty commit when needed.
 #
-# TO REMOVE THIS WORKAROUND:
-# 1. Create a PAT at https://github.com/settings/tokens/new with 'repo' and 'workflow' scopes
-# 2. Add it as repository secret named CHANGESET_GITHUB_TOKEN
-# 3. The release.yml workflow will then use the PAT and CI will run automatically
-# 4. Delete this entire workflow file
+# This is required when using a user PAT instead of a bot account PAT.
+# To avoid this workflow, create a bot account and use its PAT as CHANGESET_GITHUB_TOKEN.
 on:
   pull_request_target:
     types: [opened, reopened]
@@ -33,11 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     # Only run for changeset release PRs (automatic trigger)
     # OR when manually triggered via workflow_dispatch
+    # Works with both bot and user PATs
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
-       (github.event.pull_request.user.type == 'Bot' ||
-        endsWith(github.event.pull_request.user.login, '[bot]')))
+      startsWith(github.event.pull_request.head.ref, 'changeset-release/')
     steps:
       - name: Get PR Info
         id: pr-info


### PR DESCRIPTION
## Problem

The `changeset-pr-trigger.yml` workflow was only triggering for bot-created PRs, but the `CHANGESET_GITHUB_TOKEN` PAT is under a user account (nathanvale). This caused changeset release PRs to hang without CI running.

## Root Cause

GitHub blocks workflow triggers when PRs are created with a PAT from the repo owner. The workaround workflow had a condition that only ran for bot-created PRs:

```yaml
if: |
  github.event_name == 'workflow_dispatch' ||
  (startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
   (github.event.pull_request.user.type == 'Bot' ||
    endsWith(github.event.pull_request.user.login, '[bot]')))
```

## Solution

Removed the bot-only check. Now triggers for **any** PR with branch name starting with `changeset-release/`, regardless of whether created by bot or user PAT.

```yaml
if: |
  github.event_name == 'workflow_dispatch' ||
  startsWith(github.event.pull_request.head.ref, 'changeset-release/')
```

## Testing

Tested with PR #117 - the workflow now correctly:
1. Detects changeset release PRs
2. Checks if CI is running  
3. Pushes empty commit to trigger CI if needed

## Alternative

To avoid this workaround entirely, create a bot account and use its PAT as `CHANGESET_GITHUB_TOKEN`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI trigger rules for release PRs so they run regardless of who opened the PR.
  * Added a manual “Run workflow” option that accepts a PR number for on-demand execution.
  * Improved compatibility with both bot and user authentication tokens to ensure CI runs consistently.
  * Removed outdated guidance from workflow comments and clarified compatibility notes.
  * Retained existing manual trigger flow while reducing unnecessary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->