### PR TITLE
fix(testkit): use >= instead of > for leak detection threshold

### DIFF
--- a/.changeset/1759319334-testkit.md
+++ b/.changeset/1759319334-testkit.md
@@ -2,9 +2,6 @@
 "@orchestr8/testkit": patch
 ---
 
-Auto-generated changeset from PR commits
+Fix async test isolation and auto-changeset detached HEAD issue
 
-Commits:
-- fix: async test isolation and auto-changeset detached HEAD issue
-- chore: trigger CI for changeset release PR
-- chore(release): version packages 🚀 [skip ci]
+This patch resolves test isolation issues with async operations and fixes the detached HEAD state that occurred during automated changeset generation in CI.

--- a/packages/testkit/src/utils/process-listeners.ts
+++ b/packages/testkit/src/utils/process-listeners.ts
@@ -332,7 +332,7 @@ export class ProcessListenerManager {
 
     for (const [_listenerKey, record] of this.listeners) {
       const age = now - record.registeredAt
-      if (age > maxAge) {
+      if (age >= maxAge) {
         leaks.push({
           listener: record.listener,
           event: record.event,


### PR DESCRIPTION
## Summary
Fixes flaky test in `process-listeners-memory-leaks.test.ts` by changing the leak detection threshold comparison from `>` to `>=`.

## Changes
- Changed `detectPotentialLeaks` condition from `age > maxAge` to `age >= maxAge`
- Updated changeset to have user-facing description

## Problem
The test "should track listener age and detect old listeners" was failing intermittently because:
- It waits 1ms then checks with `maxAge=0` 
- When `age` is 0 or 1ms and the condition is `age > 0`, it evaluates to false
- This causes the test to expect 1 leak but get 0

## Solution
Using `>=` instead of `>` ensures listeners registered at the threshold age are correctly detected.

## Test plan
- ✅ All 20 tests in process-listeners-memory-leaks.test.ts pass
- ✅ Pre-commit checks passed
- ✅ Validation pipeline passed (lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leak detection in test utilities by counting listeners that reach the max-age threshold, ensuring potential leaks are flagged more reliably.

* **Chores**
  * Updated changeset entry to provide a clear, user-facing description of the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->