### PR TITLE
fix(ci): use PAT for auto-changeset to trigger CI

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CHANGESET_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Fixes the issue where CI doesn't automatically run after the auto-changeset workflow commits.

## Changes
- Changed `auto-changeset.yml` to use `CHANGESET_GITHUB_TOKEN` instead of `GITHUB_TOKEN`
- This allows CI to run automatically after changeset commits are pushed

## Problem
When the auto-changeset workflow pushed commits using `GITHUB_TOKEN`, GitHub blocked CI from running automatically (security feature to prevent workflow loops). This meant we had to manually push empty commits to trigger CI.

## Solution
Using the PAT (`CHANGESET_GITHUB_TOKEN`) instead allows CI to trigger normally, eliminating the need for manual intervention.

## Test plan
- Merge this PR
- Create a new PR that triggers auto-changeset
- Verify CI runs automatically after the changeset commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)