### PR TITLE
fix(ci): build quality-check before changeset version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           pnpm-version: ${{ env.PNPM_VERSION }}
 
-      # Trust CI - if tests failed, merge wouldn't have happened
-      # No need to re-run tests or builds here
+      # Build quality-check package (required by pre-commit hook during changeset version)
+      - name: Build quality-check package
+        run: pnpm --filter @orchestr8/quality-check build
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
Fixes release workflow failure by building quality-check package before running changeset version.

## Problem
The pre-commit hook requires quality-check dist files to exist, but the release workflow wasn't building the package before running `changeset version`, which triggered the pre-commit hook.

## Solution
Added a build step for quality-check package before the changeset action runs.

## Error
```
⚠️  Pre-commit hook error: Quality check dist files not found!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)