### PR TITLE
fix: update repository URLs for npm provenance validation

### DIFF
--- a/.changeset/lucky-animals-carry.md
+++ b/.changeset/lucky-animals-carry.md
@@ -1,0 +1,7 @@
+---
+"@orchestr8/quality-check": patch
+"@orchestr8/testkit": patch
+"@orchestr8/voice-vault": patch
+---
+
+fix: update repository URLs to match actual GitHub repository for npm provenance validation

--- a/apps/vite/package.json
+++ b/apps/vite/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nathanvale/bun-changesets-template.git",
+    "url": "https://github.com/nathanvale/orchestr8.git",
     "directory": "apps/app"
   },
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "private": true,
   "license": "MIT",
   "description": "Node.js + pnpm monorepo template with Next.js, Turborepo, Vitest, Changesets & ADHD-optimized DX",
-  "homepage": "https://github.com/nathanvale/bun-changesets-template#readme",
+  "homepage": "https://github.com/nathanvale/orchestr8#readme",
   "bugs": {
-    "url": "https://github.com/nathanvale/bun-changesets-template/issues"
+    "url": "https://github.com/nathanvale/orchestr8/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nathanvale/bun-changesets-template.git"
+    "url": "https://github.com/nathanvale/orchestr8.git"
   },
   "sideEffects": false,
   "type": "module",

--- a/packages/quality-check/package.json
+++ b/packages/quality-check/package.json
@@ -69,6 +69,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nathanvale/bun-changesets-template"
+    "url": "https://github.com/nathanvale/orchestr8"
   }
 }

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nathanvale/bun-changesets-template.git",
+    "url": "https://github.com/nathanvale/orchestr8.git",
     "directory": "packages/testkit"
   },
   "sideEffects": false,

--- a/packages/voice-vault/package.json
+++ b/packages/voice-vault/package.json
@@ -5,7 +5,7 @@
   "description": "TTS package with intelligent caching to maximize free tier usage",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nathanvale/bun-changesets-template.git",
+    "url": "https://github.com/nathanvale/orchestr8.git",
     "directory": "packages/voice-vault"
   },
   "sideEffects": false,


### PR DESCRIPTION
## Summary

Fixes npm provenance validation errors by updating repository URLs from `bun-changesets-template` to `orchestr8`.

## Problem

When attempting to publish packages, npm provenance validation failed with:

```
Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "git+https://github.com/nathanvale/bun-changesets-template.git", 
expected to match "https://github.com/nathanvale/orchestr8" from provenance
```

## Solution

Updated all `package.json` files to use the correct repository URL: `https://github.com/nathanvale/orchestr8`

## Changes

- Root `package.json`
- `packages/quality-check/package.json`
- `packages/testkit/package.json`  
- `packages/voice-vault/package.json`
- `apps/vite/package.json`

This will trigger a patch release for all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected repository, homepage, and issue tracker links across the project to point to the correct GitHub repository.
* **Chores**
  * Published patch updates for @orchestr8/quality-check, @orchestr8/testkit, and @orchestr8/voice-vault.
  * Updated package metadata to reflect the new repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->