### PR TITLE
fix(testkit): resolve ES module compatibility issues

### DIFF
--- a/.changeset/fix-testkit-es-modules.md
+++ b/.changeset/fix-testkit-es-modules.md
@@ -1,0 +1,9 @@
+---
+"@orchestr8/testkit": patch
+---
+
+Fix ES module compatibility issues
+
+- Fixed directory imports in utils/index.ts - now uses explicit .js extensions for security and resources imports
+- Added missing export for msw/handlers module in package.json
+- Improved FileDatabase type export to prevent "is not a constructor" errors

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -46,6 +46,12 @@
       "require": "./dist/cjs/msw/browser.cjs",
       "default": "./dist/msw/browser.js"
     },
+    "./msw/handlers": {
+      "types": "./dist/msw/handlers.d.ts",
+      "import": "./dist/msw/handlers.js",
+      "require": "./dist/cjs/msw/handlers.cjs",
+      "default": "./dist/msw/handlers.js"
+    },
     "./containers": {
       "vitest": "./dist/containers/index.js",
       "development": "./dist/containers/index.js",

--- a/packages/testkit/src/sqlite/file.ts
+++ b/packages/testkit/src/sqlite/file.ts
@@ -34,6 +34,12 @@ import { createManagedTempDirectory, type TempDirectory } from '../fs/index.js'
 import { registerResource, ResourceCategory } from '../resources/index.js'
 import { type SQLiteConnectionPool } from './pool.js'
 
+/**
+ * Interface representing a file-based SQLite database.
+ * Use `createFileDatabase()` or `createFileDBWithPool()` to create instances.
+ *
+ * Note: This is a TypeScript interface and cannot be used with `new` or `instanceof`.
+ */
 export interface FileDatabase {
   /** SQLite file URL (file:/path/to/db.sqlite) */
   url: string

--- a/packages/testkit/src/sqlite/index.ts
+++ b/packages/testkit/src/sqlite/index.ts
@@ -1,7 +1,10 @@
 // Public barrel for SQLite helpers (stubs for Phase 1–2)
 export * from './cleanup.js'
 export * from './errors.js'
-export * from './file.js'
+// Export FileDatabase type explicitly
+export type { FileDatabase } from './file.js'
+// Export file.js functions
+export { createFileDBWithPool, createFileDatabase, createFileSQLiteDatabase } from './file.js'
 export * from './memory.js'
 export * from './migrate.js'
 export * from './orm.js'

--- a/packages/testkit/src/utils/index.ts
+++ b/packages/testkit/src/utils/index.ts
@@ -15,7 +15,7 @@ export {
   type SecurityValidationType,
   type SecurityValidationOptions,
   type ValidationResult,
-} from '../security'
+} from '../security/index.js'
 
 // Export resource management functions
 export {
@@ -44,7 +44,7 @@ export {
   isAsyncCleanupFunction,
   DEFAULT_CATEGORY_PRIORITIES,
   DEFAULT_CATEGORY_TIMEOUTS,
-} from '../resources'
+} from '../resources/index.js'
 
 // Export concurrency control functions
 export {


### PR DESCRIPTION
## Summary
Fixes three critical ES module compatibility bugs in @orchestr8/testkit@1.0.7:

### 1. Directory imports in utils module
- Fixed `export from '../security'` to `export from '../security/index.js'`
- Fixed `export from '../resources'` to `export from '../resources/index.js'`
- ES modules require explicit file extensions for Node.js compatibility

### 2. Missing MSW handlers export
- Added `./msw/handlers` export path to package.json exports field
- Users can now directly import `@orchestr8/testkit/msw/handlers`
- Previously would throw "module not found" errors

### 3. FileDatabase type-only export
- Made FileDatabase a proper type-only export in sqlite/index.ts
- Prevents "FileDatabase is not a constructor" runtime errors
- Clarified in JSDoc that users should use `createFileDatabase()` factory function

## Impact
All changes maintain backward compatibility while fixing critical module resolution issues that prevented testkit from working properly in ES module environments.

## Test Plan
- [x] Build passes
- [x] All tests pass
- [x] Pre-commit and pre-push hooks pass
- [x] Changeset created for patch release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed msw/handlers as a public export.
  - Added FileDatabase type for file-based SQLite helpers.

- Bug Fixes
  - Improved ES module compatibility by using explicit .js paths in re-exports.
  - Prevented “is not a constructor” errors via proper FileDatabase type export and tighter sqlite exports.

- Refactor
  - Replaced wildcard sqlite exports with explicit named/type exports.

- Chores
  - Added changeset entry for release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->