### PR TITLE
fix(testkit): cleanup process listeners in afterAll to prevent hanging

### DIFF
--- a/.changeset/fix-process-listener-cleanup.md
+++ b/.changeset/fix-process-listener-cleanup.md
@@ -1,0 +1,24 @@
+---
+'@orchestr8/testkit': patch
+---
+
+fix: cleanup process listeners in afterAll and parent process to prevent hanging
+
+Fixes issue where 98 file handles remain open after tests complete, preventing the Node.js process from exiting naturally. Process would hang indefinitely requiring timeout wrappers or manual termination.
+
+**Root Cause:** register.ts called removeAllProcessListeners() in afterEach but NOT in afterAll. Additionally, with Vitest's fork pool architecture, the parent coordinator process never executes afterAll hooks, leaving its process listeners attached permanently.
+
+**Solution:**
+1. Added removeAllProcessListeners() to afterAll hook for fork workers
+2. Added process.on('exit') cleanup handler for parent process (fork pool coordinator)
+
+This ensures process listeners are cleaned up in both scenarios:
+- Fork workers: afterAll hook executes after test files complete
+- Parent process: exit handler executes when coordinator process terminates
+
+**Impact:**
+- Eliminates need for timeout wrappers in package.json
+- Natural process exit after tests complete
+- Better developer experience
+- Resolves hanging process issue with Vitest fork pools
+- Handles both single-worker and fork-pool scenarios


### PR DESCRIPTION
## Problem

After all tests complete successfully, 98 file handles remain open preventing the Node.js process from exiting naturally. Process hangs indefinitely requiring timeout wrappers or manual termination (Ctrl+C).

**Observable Behavior:**
- ✅ All tests pass successfully
- ✅ TestKit guards clean up SQLite connections and timers  
- ❌ Process hangs for 120+ seconds after tests finish
- ❌ 98 file handles prevent natural process exit

## Root Cause

**File:** `src/register.ts` (line 22)

TestKit calls `removeAllProcessListeners()` in `afterEach` but **NOT in `afterAll`**.

Additionally, with Vitest's **fork pool architecture**, the parent coordinator process:
- Loads TestKit and registers process listeners
- Spawns fork workers to run tests
- **NEVER executes afterAll hooks** (only workers do)
- Retains all 98 file handles permanently

```
┌─────────────────────────────────────────┐
│ Parent Process (Vitest Coordinator)    │
│ - Loads TestKit's register.ts           │
│ - Sets up process event listeners       │
│ - Spawns 6 fork workers                 │
│ - NEVER runs afterAll hooks ❌          │
│ - 98 file handles remain open           │
└─────────────────────────────────────────┘
         │
         ├──> Fork Worker 1 (runs tests)
         │    └─> afterAll runs ✅
         │
         ├──> Fork Worker 2 (runs tests)
         │    └─> afterAll runs ✅
         │
         └──> ... 4 more workers
```

**Evidence:**
- All 98 handles point to `process-listeners.js:281`
- User workarounds in `test-setup.ts` ran 20 times (in fork workers) but handles remain (in parent)
- Issue reproduced in https://github.com/nathanvale/capture-bridge

## Solution

**Two-part fix** addressing both fork workers AND parent process:

### 1. Fork Worker Cleanup (afterAll)
Added `removeAllProcessListeners()` to the existing `afterAll` hook:
```typescript
afterAll(async () => {
  await cleanupAllResources({ continueOnError: true })
  removeAllProcessListeners()  // ← Fork workers clean up
})
```

### 2. Parent Process Cleanup (process.on('exit'))
Added exit handler for parent coordinator process:
```typescript
if (typeof process !== 'undefined') {
  const parentProcessCleanup = () => {
    try {
      removeAllProcessListeners()
    } catch (error) {
      // Silently ignore cleanup errors during exit
    }
  }
  
  // Register exit cleanup for parent process
  process.on('exit', parentProcessCleanup)
}
```

This implements **Option 2 (Complete Fix)** from the bug report.

## Changes

- ✅ Added process listener cleanup to `afterAll` hook in `src/register.ts`
- ✅ Added parent process exit handler with cleanup
- ✅ Updated changeset documenting complete fix

## Impact

- ✅ Eliminates need for timeout wrappers in package.json
- ✅ Natural process exit after tests complete  
- ✅ Better developer experience
- ✅ Handles both single-worker and fork pool scenarios
- ✅ Resolves hanging process issue completely

## Testing

- ✅ Existing process listener tests pass (20/20)
- ✅ Build succeeds with no TypeScript errors
- ✅ Fix verified to resolve issue in capture-bridge test suite

## Related Issue

Fixes the hanging process issue described in:
https://github.com/nathanvale/capture-bridge/blob/feat/GMAIL_OAUTH2_SETUP--T01/docs/backlog/TESTKIT-ISSUE-REPORT-FINAL.md

---

**Note:** This is a critical bug fix for TestKit 2.1.x that prevents natural process exit after tests complete. The fix addresses both fork workers (via afterAll) and the parent process (via exit handler).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures process event listeners are cleaned up after test suites and when the parent process exits, preventing hanging test runs, reducing reliance on timeout wrappers, and mitigating fork-pool stalls.

* **Documentation**
  * Added a changeset describing the cleanup improvement and its impact on test stability and natural exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->