### PR TITLE
chore: add changeset for testkit setup module feature

### DIFF
--- a/.changeset/testkit-setup-module.md
+++ b/.changeset/testkit-setup-module.md
@@ -1,0 +1,39 @@
+---
+'@orchestr8/testkit': minor
+---
+
+Add pre-configured test setup module with automatic resource cleanup
+
+Introduces `@orchestr8/testkit/setup` and `@orchestr8/testkit/setup/auto` modules to eliminate test-setup.ts boilerplate across packages.
+
+**Features:**
+- `@orchestr8/testkit/setup` - Manual configuration with `createTestSetup()` factory
+- `@orchestr8/testkit/setup/auto` - Zero-config auto-executing setup for vitest setupFiles
+- Centralized resource cleanup with sensible defaults
+- Optional package name logging and statistics
+- Full TypeScript support with proper type exports
+
+**Usage:**
+
+Zero-config (auto-executing):
+```typescript
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    setupFiles: ['@orchestr8/testkit/setup/auto']
+  }
+})
+```
+
+Custom configuration:
+```typescript
+import { createTestSetup } from '@orchestr8/testkit/setup'
+
+await createTestSetup({
+  packageName: 'my-package',
+  cleanupAfterEach: false,
+  logStats: true
+})
+```
+
+This eliminates 101 lines of duplicated boilerplate code across packages.


### PR DESCRIPTION
Adds changeset for the testkit setup module feature introduced in PR #171.

This changeset will trigger the Changesets bot to create a "Version Packages" PR.

## Changes
- Adds `.changeset/testkit-setup-module.md` for `@orchestr8/testkit` minor version bump

## Feature Summary
The setup module eliminates 101 lines of test-setup.ts boilerplate by providing:
- `@orchestr8/testkit/setup` - Manual configuration with createTestSetup()
- `@orchestr8/testkit/setup/auto` - Zero-config auto-executing setup

Once merged, this will trigger the automated versioning workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added guidance for a pre-configured test setup with both zero‑config and customizable options.
  - Included usage examples for auto-executing setup and manual configuration.
  - Documented centralized resource cleanup with sensible defaults.
  - Highlighted optional logging and test statistics.
  - Clarified full TypeScript support with proper type exports.
  - Emphasized reduction of boilerplate across packages by consolidating setup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->