### PR TITLE
feat(quality-check): centralize logs to .logs/ directory at git root

### DIFF
--- a/.changeset/centralized-logging.md
+++ b/.changeset/centralized-logging.md
@@ -1,0 +1,31 @@
+---
+"@orchestr8/quality-check": minor
+---
+
+feat: centralize logs to .logs/ directory at git root
+
+**Problem:**
+Log files were being created in multiple scattered locations throughout the monorepo:
+- `./packages/quality-check/logs`
+- `./apps/migration-cli/packages/quality-check/logs`  
+- `./apps/portal/packages/quality-check/logs`
+
+**Solution:**
+All quality-check logs now write to a single, centralized `.logs/` directory:
+- **Default:** `<git-root>/.logs/quality-check/{errors,debug}/`
+- **Fallback:** `<cwd>/.logs/quality-check/{errors,debug}/` (if not in a git repo)
+
+**Features:**
+- ✨ Auto-detect git repository root for centralized logging
+- 🔧 Environment variable support: `QUALITY_CHECK_LOG_DIR`
+- 📝 Updated `.gitignore` to exclude `.logs/` directory
+- 🧹 Cleaner monorepo workspace - no more scattered log directories
+
+**Configuration Priority:**
+1. Explicit `logDir` config option
+2. `QUALITY_CHECK_LOG_DIR` environment variable  
+3. Git root `.logs/` directory (auto-detected)
+4. Current directory `.logs/` (fallback)
+
+**Breaking Changes:**
+None - backward compatible. Existing log directories will be ignored and new logs write to centralized location.

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ desktop.ini
 
 # Logs
 logs/
+.logs/
 *.log
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary
Centralizes all quality-check logs to a single `.logs/` directory at the git repository root instead of scattered `logs/` directories throughout the monorepo.

## Problem
Log files were being created in multiple scattered locations:
- `./packages/quality-check/logs`
- `./apps/migration-cli/packages/quality-check/logs`  
- `./apps/portal/packages/quality-check/logs`

This created clutter and made it difficult to find logs across the monorepo.

## Solution
All quality-check logs now write to a single, centralized `.logs/` directory:
- **Default:** `<git-root>/.logs/quality-check/{errors,debug}/`
- **Fallback:** `<cwd>/.logs/quality-check/{errors,debug}/` (if not in a git repo)

## Features
- ✨ Auto-detect git repository root for centralized logging
- 🔧 Environment variable support: `QUALITY_CHECK_LOG_DIR`
- 📝 Updated `.gitignore` to exclude `.logs/` directory
- 🧹 Cleaner monorepo workspace - no more scattered log directories

## Configuration Priority
1. Explicit `logDir` config option
2. `QUALITY_CHECK_LOG_DIR` environment variable  
3. Git root `.logs/` directory (auto-detected)
4. Current directory `.logs/` (fallback)

## Testing
Verified git root detection and log directory creation:
```
Git Root: /Users/nathanvale/code/@orchestr8
Log Directory: /Users/nathanvale/code/@orchestr8/.logs
Error Logs: /Users/nathanvale/code/@orchestr8/.logs/quality-check/errors
Debug Logs: /Users/nathanvale/code/@orchestr8/.logs/quality-check/debug
```

## Breaking Changes
None - backward compatible. Existing log directories will be ignored and new logs write to centralized location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented centralized logging for quality-check operations with logs stored in a unified `.logs` directory.
  * Added support for the `QUALITY_CHECK_LOG_DIR` environment variable to customize log directory location, with automatic fallback to the current directory when git root is unavailable.
  * Updated .gitignore to reflect new centralized logging directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->