### PR TITLE
fix(quality-check): use logs/ instead of .logs/ for centralized logging

### DIFF
--- a/.changeset/fix-logs-directory.md
+++ b/.changeset/fix-logs-directory.md
@@ -1,0 +1,12 @@
+---
+"@orchestr8/quality-check": patch
+---
+
+fix: use logs/ instead of .logs/ for centralized log directory
+
+Changes the centralized log directory from `.logs/` to `logs/` at the git repository root.
+
+- **Before:** `<git-root>/.logs/quality-check/{errors,debug}/`
+- **After:** `<git-root>/logs/quality-check/{errors,debug}/`
+
+The `logs/` directory is already covered by `.gitignore`.

--- a/packages/quality-check/src/utils/logger.ts
+++ b/packages/quality-check/src/utils/logger.ts
@@ -381,14 +381,14 @@ export class EnhancedLogger extends QualityLogger {
     // Determine log directory with priority:
     // 1. Explicit config
     // 2. Environment variable
-    // 3. Git root .logs/ (if in git repo)
-    // 4. Current directory .logs/
+    // 3. Git root logs/ (if in git repo)
+    // 4. Current directory logs/
     const defaultLogDir = (() => {
       if (process.env.QUALITY_CHECK_LOG_DIR) {
         return process.env.QUALITY_CHECK_LOG_DIR
       }
       const gitRoot = findGitRoot()
-      return gitRoot ? join(gitRoot, '.logs') : join(process.cwd(), '.logs')
+      return gitRoot ? join(gitRoot, 'logs') : join(process.cwd(), 'logs')
     })()
 
     this.config = {


### PR DESCRIPTION
## Summary
Fixes the centralized log directory to use `logs/` instead of `.logs/` at the git repository root.

## Changes
- Updated logger to use `logs/` instead of `.logs/`
- Directory structure remains: `<git-root>/logs/quality-check/{errors,debug}/`
- No changes needed to `.gitignore` (already covers `logs/`)

## Before/After
- **Before:** `<git-root>/.logs/quality-check/{errors,debug}/`
- **After:** `<git-root>/logs/quality-check/{errors,debug}/`

## Impact
Patch release - fixes directory location from hidden directory to standard logs directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default log directory path from `.logs/` to `logs/` at the repository root. Quality check logs are now stored in a more accessible, visible directory while remaining excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->